### PR TITLE
feat(kind): set base path for kind files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kind.yaml

--- a/kubernetes/kind/configs/agent/kind.yaml.template
+++ b/kubernetes/kind/configs/agent/kind.yaml.template
@@ -4,14 +4,14 @@ nodes:
 - role: control-plane
   extraMounts:
     # hostPath must match the path to the dist folder of the portainer project
-  - hostPath: /home/baron_l/projects/pro/portainer/portainer/dist
+  - hostPath: _PORTAINER_PATH_/dist
     containerPath: /portainer/app
   extraPortMappings:
   - containerPort: 9000
     # hostPort will be the port to use to access portainer instance at localhost:hostPort
-    hostPort: 9050
-  # - containerPort: 8000
-  #   hostPort: 8000
+    hostPort: 9000
+  - containerPort: 8000
+    hostPort: 8000
   # port 30778 of the host (not the kind instance but host computer) is bound to edge-agent port 9001
   - containerPort: 30778
     hostPort: 30778

--- a/kubernetes/kind/configs/agent/kind.yaml.template
+++ b/kubernetes/kind/configs/agent/kind.yaml.template
@@ -9,9 +9,9 @@ nodes:
   extraPortMappings:
   - containerPort: 9000
     # hostPort will be the port to use to access portainer instance at localhost:hostPort
-    hostPort: 9000
-  - containerPort: 8000
-    hostPort: 8000
+    hostPort: 9050
+  # - containerPort: 8000
+  #   hostPort: 8000
   # port 30778 of the host (not the kind instance but host computer) is bound to edge-agent port 9001
   - containerPort: 30778
     hostPort: 30778

--- a/kubernetes/kind/configs/base/kind.yaml.template
+++ b/kubernetes/kind/configs/base/kind.yaml.template
@@ -4,13 +4,13 @@ nodes:
 - role: control-plane
   extraMounts:
     # hostPath must match the path to the dist folder of the portainer project
-  - hostPath: /home/baron_l/projects/pro/portainer/portainer/dist
+  - hostPath: _PORTAINER_PATH_/dist
     containerPath: /portainer/app
   extraPortMappings:
   - containerPort: 9000
     # hostPort will be the port to use to access portainer instance at localhost:hostPort
-    hostPort: 9040
-  # - containerPort: 8000
-  #   hostPort: 8000
-- role: worker
-- role: worker
+    hostPort: 9010
+  #- containerPort: 8000
+  #  hostPort: 8000
+# uncomment to following line to have a 2 nodes cluster (1 master + 1 worker)
+# - role: worker

--- a/kubernetes/kind/configs/basetmp/kind.yaml.template
+++ b/kubernetes/kind/configs/basetmp/kind.yaml.template
@@ -4,13 +4,11 @@ nodes:
 - role: control-plane
   extraMounts:
     # hostPath must match the path to the dist folder of the portainer project
-  - hostPath: /home/baron_l/projects/pro/portainer/portainer/dist
+  - hostPath: _PORTAINER_PATH_/dist
     containerPath: /portainer/app
   extraPortMappings:
   - containerPort: 9000
     # hostPort will be the port to use to access portainer instance at localhost:hostPort
-    hostPort: 9030
+    hostPort: 9110
   # - containerPort: 8000
   #   hostPort: 8000
-- role: control-plane
-- role: control-plane

--- a/kubernetes/kind/configs/edge-agent/kind.yaml.template
+++ b/kubernetes/kind/configs/edge-agent/kind.yaml.template
@@ -4,7 +4,7 @@ nodes:
 - role: control-plane
   extraMounts:
     # hostPath must match the path to the dist folder of the portainer project
-  - hostPath: /home/baron_l/projects/pro/portainer/portainer/dist
+  - hostPath: _PORTAINER_PATH_/dist
     containerPath: /portainer/app
   extraPortMappings:
   - containerPort: 9000

--- a/kubernetes/kind/configs/ingress/kind.yaml.template
+++ b/kubernetes/kind/configs/ingress/kind.yaml.template
@@ -13,7 +13,7 @@ nodes:
         node-labels: "ingress-ready=true"
   extraMounts:
     # hostPath must match the path to the dist folder of the portainer project
-  - hostPath: /home/baron_l/projects/pro/portainer/portainer/dist
+  - hostPath: _PORTAINER_PATH_/dist
     containerPath: /portainer/app
   extraPortMappings:
   - containerPort: 9000

--- a/kubernetes/kind/configs/multi-master/kind.yaml.template
+++ b/kubernetes/kind/configs/multi-master/kind.yaml.template
@@ -4,13 +4,13 @@ nodes:
 - role: control-plane
   extraMounts:
     # hostPath must match the path to the dist folder of the portainer project
-  - hostPath: /home/baron_l/projects/pro/portainer/portainer/dist
+  - hostPath: _PORTAINER_PATH_/dist
     containerPath: /portainer/app
   extraPortMappings:
   - containerPort: 9000
     # hostPort will be the port to use to access portainer instance at localhost:hostPort
-    hostPort: 9010
-  #- containerPort: 8000
-  #  hostPort: 8000
-# uncomment to following line to have a 2 nodes cluster (1 master + 1 worker)
-# - role: worker
+    hostPort: 9030
+  # - containerPort: 8000
+  #   hostPort: 8000
+- role: control-plane
+- role: control-plane

--- a/kubernetes/kind/configs/taints/kind.yaml.template
+++ b/kubernetes/kind/configs/taints/kind.yaml.template
@@ -4,11 +4,13 @@ nodes:
 - role: control-plane
   extraMounts:
     # hostPath must match the path to the dist folder of the portainer project
-  - hostPath: /home/baron_l/projects/pro/portainer/tmp_portainer/dist
+  - hostPath: _PORTAINER_PATH_/dist
     containerPath: /portainer/app
   extraPortMappings:
   - containerPort: 9000
     # hostPort will be the port to use to access portainer instance at localhost:hostPort
-    hostPort: 9110
+    hostPort: 9040
   # - containerPort: 8000
   #   hostPort: 8000
+- role: worker
+- role: worker

--- a/kubernetes/kind/setup.sh
+++ b/kubernetes/kind/setup.sh
@@ -2,6 +2,18 @@
 
 CONFIGS_PATH="./configs"
 
+#region SETUP ENV
+
+setup() {
+  PORTAINER_BASE=$1
+  for f in $(find  -name kind.yaml.template); do
+    sed "s#_PORTAINER_PATH_#$PORTAINER_BASE#g" $f > $(dirname $f)/kind.yaml;
+  done
+}
+
+#endregion
+
+
 #region CLUSTER MANAGEMENT
 create() {
   kind create cluster --config=$CONFIGS_PATH/$1/kind.yaml --name $1
@@ -40,6 +52,7 @@ usage() {
 Usage: ./setup.sh ACTION CONTEXT [CONFIG_FILE]
 
 with: - ACTION one of
+          setup
           create | delete | recreate | portainer
           deploy | redeploy | remove
           help | usage | *
@@ -47,6 +60,9 @@ with: - ACTION one of
       - CONFIG_FILE any .yaml config to deploy
 
 ACTIONS:
+  - ./setup.sh setup PORTAINER_BASE
+    * will create kind files where the base path is set to PORTAINER_BASE
+
   - ./setup.sh [ create | delete | recreate | portainer ] CONTEXT
     * create: create a new cluster defined by configs/CONTEXT/kind.yaml
     * delete: delete cluster defined by configs/CONTEXT/kind.yaml
@@ -64,7 +80,7 @@ ACTIONS:
 }
 
 case $1 in
-create | recreate | portainer | delete)
+create | recreate | portainer | delete | setup)
   if [[ $# == 2 ]]; then
     $1 $2
   else


### PR DESCRIPTION
This PR adds the option to run `./setup.sh setup /home/chiptus/portainer` and it will set all kind.yaml files with the correct base path.

I intently renamed the kind.yaml to kind.yaml.template to make the user run it on the beginning
